### PR TITLE
Replace standalone Dragonfly with Valkey sentinel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ go.work.sum
 *.yaml
 !Pulumi.dev.yaml
 !Pulumi.yaml
+!kind-config.yaml

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,30 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: dual
+name: kind
+# 1 control plane nodes and 5 workers
+nodes:
+  # the control plane node config
+  - role: control-plane
+    image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
+    # SEE: https://github.com/kubernetes-sigs/cloud-provider-kind?tab=readme-ov-file#allowing-load-balancers-access-to-control-plane-nodes
+    # Without this annotation, the control-plane node can have workloads scheduled on it, and those workloads would be
+    # inaccessible to any LoadBalancer type Service.
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            register-with-taints: "node-role.kubernetes.io/master:NoSchedule"
+  # the five workers
+  - role: worker
+    image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
+  - role: worker
+    image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
+  - role: worker
+    image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
+  - role: worker
+    image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
+  - role: worker
+    image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/fjarm/infrastructure/pkg/v1/certmanager"
-	"github.com/fjarm/infrastructure/pkg/v1/dragonfly"
+	"github.com/fjarm/infrastructure/pkg/v1/valkey"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -19,11 +19,19 @@ func main() {
 		if err != nil {
 			return err
 		}
-		deps, err := certmanager.DeployCertManager(ctx, k8sProvider)
+		certManagerDeps, err := certmanager.DeployCertManager(
+			ctx,
+			k8sProvider,
+		)
 		if err != nil {
 			return err
 		}
-		err = dragonfly.DeployDragonfly(ctx, k8sProvider, deps)
+
+		_, err = valkey.DeployValkeyCluster(
+			ctx,
+			k8sProvider,
+			certManagerDeps,
+		)
 		return err
 	})
 }

--- a/pkg/v1/dragonfly/dragonfly_cluster.go
+++ b/pkg/v1/dragonfly/dragonfly_cluster.go
@@ -1,0 +1,83 @@
+package dragonfly
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apiextensions"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	clusterAppLabel        = "dragonfly"
+	clusterInstanceLabel   = "dragonfly-instance"
+	clusterName            = "dragonfly-cluster"
+	clusterNameLabel       = "dragonfly-cluster"
+	dragonflyCRDAPIVersion = "dragonflydb.io/v1alpha1"
+	dragonflyCRDKind       = "Dragonfly"
+)
+
+// deployDragonflyCluster deploys a DragonflyDB cluster using the Dragonfly Operator's CRD.
+func deployDragonflyCluster(
+	ctx *pulumi.Context,
+	namespace *corev1.Namespace,
+	provider *kubernetes.Provider,
+	deps []pulumi.Resource,
+) (pulumi.Resource, error) {
+	clusterArgs := newDragonflyClusterArgs(namespace)
+	cluster, err := apiextensions.NewCustomResource(
+		ctx,
+		clusterName,
+		clusterArgs,
+		pulumi.Provider(provider),
+		pulumi.DependsOn(deps),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return cluster, nil
+}
+
+// newDragonflyClusterArgs returns the Dragonfly cluster spec that will be converted to YAML and applied to the cluster.
+func newDragonflyClusterArgs(
+	namespace *corev1.Namespace,
+) *apiextensions.CustomResourceArgs {
+	return &apiextensions.CustomResourceArgs{
+		ApiVersion: pulumi.String(dragonflyCRDAPIVersion),
+		Kind:       pulumi.String(dragonflyCRDKind),
+		Metadata: metav1.ObjectMetaArgs{
+			Name:      pulumi.String(clusterName),
+			Namespace: namespace.Metadata.Name(),
+			Labels: pulumi.StringMap{
+				"app":                        pulumi.String(clusterAppLabel),
+				"app.kubernetes.io/instance": pulumi.String(clusterInstanceLabel),
+				"app.kubernetes.io/name":     pulumi.String(clusterNameLabel),
+				"app.kubernetes.io/part-of":  pulumi.String(operatorAppLabel),
+			},
+		},
+		OtherFields: kubernetes.UntypedArgs{
+			"spec": kubernetes.UntypedArgs{
+				"replicas": pulumi.Int(3), // 1 primary and 2 replicas
+				"image":    pulumi.String("docker.dragonflydb.io/dragonflydb/dragonfly:v1.30.3"),
+				"resources": pulumi.Map{
+					"limits": pulumi.Map{
+						"cpu":    pulumi.String("600m"),
+						"memory": pulumi.String("750Mi"),
+					},
+					"requests": pulumi.Map{
+						"cpu":    pulumi.String("500m"),
+						"memory": pulumi.String("500Mi"),
+					},
+				},
+				"args": pulumi.StringArray{
+					pulumi.String("--cluster_mode=yes"),
+					pulumi.String("--bind=127.0.0.1"), // IPv4 loopback interface
+					pulumi.String("--admin_port=8000"),
+					pulumi.String("--dir=/data"),
+					pulumi.String("--dbfilename=dragonfly-dump"), // No {timestamp} macro to not create multiple files that consume space on the volume.
+					pulumi.String("--snapshot_cron=0 * * * *"),   // Snapshot at minute 0 of every hour
+				},
+			},
+		},
+	}
+}

--- a/pkg/v1/dragonfly/dragonfly_cluster.go
+++ b/pkg/v1/dragonfly/dragonfly_cluster.go
@@ -70,9 +70,11 @@ func newDragonflyClusterArgs(
 					},
 				},
 				"args": pulumi.StringArray{
-					pulumi.String("--cluster_mode=yes"),
 					pulumi.String("--bind=127.0.0.1"), // IPv4 loopback interface
-					pulumi.String("--admin_port=8000"),
+					// SEE: https://github.com/dragonflydb/dragonfly-operator/blob/c70f578b5c64372ca41718be830e0629f2f144ef/internal/resources/resources.go#L114-L115
+					// SEE: https://github.com/dragonflydb/dragonfly-operator/blob/3425e0b0623f785084f0cf1463bc58ca379bf408/internal/resources/const.go#L101
+					// Dragonfly hard-codes HEALTHCHECK_PORT and --admin_port to 9999 and overrides don't work.
+					//pulumi.String("--admin_port=9999"),
 					pulumi.String("--dir=/data"),
 					pulumi.String("--dbfilename=dragonfly-dump"), // No {timestamp} macro to not create multiple files that consume space on the volume.
 					pulumi.String("--snapshot_cron=0 * * * *"),   // Snapshot at minute 0 of every hour

--- a/pkg/v1/dragonfly/dragonfly_cluster_acl_secret.go
+++ b/pkg/v1/dragonfly/dragonfly_cluster_acl_secret.go
@@ -1,0 +1,65 @@
+package dragonfly
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const clusterACLSecretName = "dragonfly-cluster-acls"
+
+// deployDragonflyClusterACLSecret constructs and deploys a secret containing the Dragonfly ACL.
+func deployDragonflyClusterACLSecret(
+	ctx *pulumi.Context,
+	namespace *corev1.Namespace,
+	provider *kubernetes.Provider,
+	deps []pulumi.Resource,
+) (*corev1.Secret, error) {
+	aclContent, err := parseDragonflyClusterUserToTemplate(dragonflyClusterUser{
+		Username:        "test",
+		Password:        "password",
+		EnabledCommands: []string{"+@ALL"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	aclSecretArgs := newDragonflyClusterACLSecretArgs(namespace, aclContent)
+	aclSecret, err := corev1.NewSecret(
+		ctx,
+		clusterACLSecretName,
+		aclSecretArgs,
+		pulumi.Provider(provider),
+		pulumi.DependsOn(deps),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return aclSecret, nil
+}
+
+// newDragonflyClusterACLSecretArgs sets up a secret containing the Dragonfly ACL file contents.
+func newDragonflyClusterACLSecretArgs(
+	namespace *corev1.Namespace,
+	aclContent string,
+) *corev1.SecretArgs {
+	return &corev1.SecretArgs{
+		ApiVersion: pulumi.String("v1"),
+		Kind:       pulumi.String("Secret"),
+		Type:       pulumi.String("Opaque"),
+		Metadata: metav1.ObjectMetaArgs{
+			Name:      pulumi.String(clusterACLSecretName),
+			Namespace: namespace.Metadata.Name(),
+			Labels: pulumi.StringMap{
+				"app":                        pulumi.String(clusterAppLabel),
+				"app.kubernetes.io/instance": pulumi.String(clusterInstanceLabel),
+				"app.kubernetes.io/name":     pulumi.String(clusterNameLabel),
+				"app.kubernetes.io/part-of":  pulumi.String(operatorAppLabel),
+			},
+		},
+		StringData: pulumi.StringMap{
+			clusterACLSecretName: pulumi.String(aclContent),
+		},
+	}
+}

--- a/pkg/v1/dragonfly/dragonfly_cluster_acls.go
+++ b/pkg/v1/dragonfly/dragonfly_cluster_acls.go
@@ -1,0 +1,53 @@
+package dragonfly
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+// ErrTemplateParsingError indicates that there was an issue parsing the acls template that resulted in an empty result
+// or a result containing `<nil>`.
+var ErrTemplateParsingError = fmt.Errorf("error parsing ACL file template")
+
+const acls = `
+user default on nopass -@ALL +PING +AUTH
+
+{{ range $index, $user := .Users }}
+user {{ $user.Username }} on >{{ $user.Password }} {{ range $cmd := $user.EnabledCommands }}{{ $cmd }} {{ end }}
+{{ end }}
+`
+
+// dragonflyClusterUser defines a user in the DragonflyDB ACL file.
+type dragonflyClusterUser struct {
+	Username        string
+	Password        string
+	EnabledCommands []string
+}
+
+func parseDragonflyClusterUserToTemplate(
+	dragonflyClusterUsers ...dragonflyClusterUser,
+) (string, error) {
+	aclTemplate, err := template.New("dragonfly.acl").Parse(acls)
+	if err != nil {
+		return "", err
+	}
+
+	templateData := struct {
+		Users []dragonflyClusterUser
+	}{
+		Users: dragonflyClusterUsers,
+	}
+	templateDestination := bytes.NewBuffer(nil)
+	err = aclTemplate.Execute(templateDestination, &templateData)
+	if err != nil {
+		return "", err
+	}
+
+	contents := templateDestination.String()
+	if contents == "" || contents == "<nil>" {
+		return "", ErrTemplateParsingError
+	}
+
+	return contents, nil
+}

--- a/pkg/v1/dragonfly/dragonfly_cluster_namespace.go
+++ b/pkg/v1/dragonfly/dragonfly_cluster_namespace.go
@@ -1,0 +1,42 @@
+package dragonfly
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	clusterNamespace = "dragonfly-cluster"
+)
+
+// deployDragonflyClusterNamespace creates the `dragonfly-cluster` namespace.
+func deployDragonflyClusterNamespace(
+	ctx *pulumi.Context,
+	provider *kubernetes.Provider,
+) (*corev1.Namespace, error) {
+	args := newDragonflyClusterNamespaceArgs()
+	ns, err := corev1.NewNamespace(
+		ctx,
+		clusterNamespace,
+		args,
+		pulumi.Provider(provider),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ns, nil
+}
+
+// newDragonflyClusterNamespaceArgs returns the corev1.NamespaceArgs used to create the `dragonfly-cluster` namespace.
+func newDragonflyClusterNamespaceArgs() *corev1.NamespaceArgs {
+	return &corev1.NamespaceArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name: pulumi.String(clusterNamespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String(clusterAppLabel),
+			},
+		},
+	}
+}

--- a/pkg/v1/dragonfly/dragonfly_helm_release.go
+++ b/pkg/v1/dragonfly/dragonfly_helm_release.go
@@ -86,9 +86,11 @@ func newDragonflyHelmChartArgs(ns *corev1.Namespace, cm *corev1.ConfigMap) *helm
 			},
 			"extraArgs": pulumi.StringArray{
 				pulumi.String("--cluster_mode=emulated"),
+				pulumi.String("--bind=127.0.0.1"), // IPv4 loopback interface
 				pulumi.String("--admin_port=8000"),
-				pulumi.String("--dbfilename=dragonfly-data-dump"),
-				pulumi.String("--snapshot_cron=0 * * * *"), // Snapshot every hour
+				pulumi.String("--dir=/data"),
+				pulumi.String("--dbfilename=dragonfly-data-dump-{timestamp}"),
+				pulumi.String("--snapshot_cron=0 * * * *"), // Snapshot at minute 0 of every hour
 				// TODO(2025-06-06): Update this to be more secure
 				pulumi.String("--requirepass=password"),
 				pulumi.String("--tls"),

--- a/pkg/v1/dragonfly/dragonfly_operator_helm_chart.go
+++ b/pkg/v1/dragonfly/dragonfly_operator_helm_chart.go
@@ -1,0 +1,77 @@
+package dragonfly
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	helmv4 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v4"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	operatorAppLabel     = "dragonfly-operator"
+	operatorChartName    = "dragonfly-operator"
+	operatorChartRepo    = "oci://ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator"
+	operatorChartVersion = "v1.1.11"
+)
+
+// DeployDragonflyOperatorHelmChart deploys the DragonflyDB operator using its Helm chart that can be found on GitHub
+// packages.
+//
+// The return value is an array of the installed dependencies.
+func DeployDragonflyOperatorHelmChart(
+	ctx *pulumi.Context,
+	provider *kubernetes.Provider,
+	deps []pulumi.Resource,
+) ([]pulumi.Resource, error) {
+	ns, err := newDragonflyOperatorNamespace(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+	chartArgs := newDragonflyOperatorHelmChartArgs(ns)
+	chart, err := helmv4.NewChart(
+		ctx,
+		operatorChartName,
+		chartArgs,
+		pulumi.Provider(provider),
+		pulumi.DependsOn(deps),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.Export("dragonflyOperatorNamespace", ns.Metadata.Name())
+
+	return []pulumi.Resource{ns, chart}, nil
+}
+
+// newDragonflyOperatorHelmChartArgs returns the Helm chart args used to deploy the Dragonfly Operator using the Helm
+// chart.
+func newDragonflyOperatorHelmChartArgs(
+	namespace *corev1.Namespace,
+) *helmv4.ChartArgs {
+	chartArgs := &helmv4.ChartArgs{
+		Chart:     pulumi.String(operatorChartRepo),
+		Namespace: namespace.Metadata.Name(),
+		Version:   pulumi.String(operatorChartVersion),
+		Values: pulumi.Map{
+			"replicaCount": pulumi.Int(3),
+			"crds": pulumi.Map{
+				"install": pulumi.Bool(true),
+				"keep":    pulumi.Bool(false),
+			},
+			"manager": pulumi.Map{
+				"resources": pulumi.Map{
+					"limits": pulumi.Map{
+						"cpu":    pulumi.String("500m"),
+						"memory": pulumi.String("128Mi"),
+					},
+					"requests": pulumi.Map{
+						"cpu":    pulumi.String("10m"),
+						"memory": pulumi.String("64Mi"),
+					},
+				},
+			},
+		},
+	}
+	return chartArgs
+}

--- a/pkg/v1/dragonfly/dragonfly_operator_helm_chart.go
+++ b/pkg/v1/dragonfly/dragonfly_operator_helm_chart.go
@@ -23,7 +23,7 @@ func DeployDragonflyOperatorHelmChart(
 	provider *kubernetes.Provider,
 	deps []pulumi.Resource,
 ) ([]pulumi.Resource, error) {
-	ns, err := newDragonflyOperatorNamespace(ctx, provider)
+	ns, err := deployDragonflyOperatorNamespace(ctx, provider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/v1/dragonfly/dragonfly_operator_namespace.go
+++ b/pkg/v1/dragonfly/dragonfly_operator_namespace.go
@@ -1,0 +1,42 @@
+package dragonfly
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	operatorNamespace = "dragonfly-operator"
+)
+
+// newDragonflyOperatorNamespace creates the `dragonfly-operator` namespace.
+func newDragonflyOperatorNamespace(
+	ctx *pulumi.Context,
+	provider *kubernetes.Provider,
+) (*corev1.Namespace, error) {
+	args := newDragonflyOperatorNamespaceArgs()
+	ns, err := corev1.NewNamespace(
+		ctx,
+		operatorNamespace,
+		args,
+		pulumi.Provider(provider),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ns, nil
+}
+
+// newDragonflyOperatorNamespaceArgs returns the corev1.NamespaceArgs used to create the `dragonfly-operator` namespace.
+func newDragonflyOperatorNamespaceArgs() *corev1.NamespaceArgs {
+	return &corev1.NamespaceArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name: pulumi.String(operatorNamespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String(operatorAppLabel),
+			},
+		},
+	}
+}

--- a/pkg/v1/dragonfly/dragonfly_operator_namespace.go
+++ b/pkg/v1/dragonfly/dragonfly_operator_namespace.go
@@ -11,8 +11,8 @@ const (
 	operatorNamespace = "dragonfly-operator"
 )
 
-// newDragonflyOperatorNamespace creates the `dragonfly-operator` namespace.
-func newDragonflyOperatorNamespace(
+// deployDragonflyOperatorNamespace creates the `dragonfly-operator` namespace.
+func deployDragonflyOperatorNamespace(
 	ctx *pulumi.Context,
 	provider *kubernetes.Provider,
 ) (*corev1.Namespace, error) {

--- a/pkg/v1/valkey/valkey_certificate.go
+++ b/pkg/v1/valkey/valkey_certificate.go
@@ -1,0 +1,94 @@
+package valkey
+
+import (
+	"fmt"
+	"github.com/fjarm/infrastructure/pkg/v1/certmanager"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apiextensions"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	clusterCertificateName       = "valkey-certificate"
+	clusterCertificateSecretName = "valkey-tls-secret"
+)
+
+// deployValkeyClusterCertificate deploys a cert-manager created/managed TLS certificate in the `valkey` namespace.
+func deployValkeyClusterCertificate(
+	ctx *pulumi.Context,
+	namespace *corev1.Namespace,
+	provider *kubernetes.Provider,
+	deps []pulumi.Resource,
+) (*apiextensions.CustomResource, error) {
+	certArgs, err := newValkeyClusterCertificateArgs(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := apiextensions.NewCustomResource(
+		ctx,
+		clusterCertificateName,
+		certArgs,
+		pulumi.Provider(provider),
+		pulumi.DependsOn(deps),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return cert, nil
+}
+
+// newValkeyClusterCertificateArgs creates a new Certificate issued by cert-manager for Valkey to use.
+func newValkeyClusterCertificateArgs(ns *corev1.Namespace) (*apiextensions.CustomResourceArgs, error) {
+	cra := apiextensions.CustomResourceArgs{
+		ApiVersion: pulumi.String("cert-manager.io/v1"),
+		Kind:       pulumi.String("Certificate"),
+		Metadata: metav1.ObjectMetaArgs{
+			Name:      pulumi.String(clusterCertificateName),
+			Namespace: ns.Metadata.Name(),
+			Labels: pulumi.StringMap{
+				"app":                          pulumi.String(clusterAppLabel),
+				"app.kubernetes.io/managed-by": pulumi.String("Helm"),
+				"app.kubernetes.io/version":    pulumi.String(chartVersion),
+				"helm.sh/chart":                pulumi.String(fmt.Sprintf("%s-%s", chartName, chartVersion)),
+			},
+		},
+		OtherFields: kubernetes.UntypedArgs{
+			"spec": kubernetes.UntypedArgs{
+				"commonName": pulumi.String("valkey"),
+				"dnsNames": pulumi.StringArray{
+					pulumi.String("'*.valkey.valkey.svc.cluster.local'"),
+					pulumi.String("valkey.valkey.svc.cluster.local"),
+					pulumi.String("valkey.valkey.svc"),
+					pulumi.String("valkey.valkey"),
+					pulumi.String("valkey"),
+					pulumi.String("'*.valkey-headless.valkey.svc.cluster.local'"),
+					pulumi.String("valkey-headless.valkey.svc.cluster.local"),
+					pulumi.String("valkey-headless.valkey.svc"),
+					pulumi.String("valkey-headless.valkey"),
+					pulumi.String("valkey-headless"),
+					pulumi.String("localhost"),
+				},
+				"duration": pulumi.String("87600h0m0s"),
+				"ipAddresses": pulumi.StringArray{
+					pulumi.String("127.0.0.1"),
+				},
+				"issuerRef": kubernetes.UntypedArgs{
+					"kind":  pulumi.String("ClusterIssuer"),
+					"name":  pulumi.String(certmanager.InternalClusterIssuerName),
+					"group": pulumi.String("cert-manager.io"),
+				},
+				"secretName": pulumi.String(clusterCertificateSecretName),
+				"usages": pulumi.StringArray{
+					pulumi.String("client auth"),
+					pulumi.String("server auth"),
+					pulumi.String("signing"),
+					pulumi.String("key encipherment"),
+				},
+			},
+		},
+	}
+	return &cra, nil
+}

--- a/pkg/v1/valkey/valkey_certificate.go
+++ b/pkg/v1/valkey/valkey_certificate.go
@@ -64,7 +64,7 @@ func newValkeyClusterCertificateArgs(ns *corev1.Namespace) (*apiextensions.Custo
 					pulumi.String("valkey.valkey.svc"),
 					pulumi.String("valkey.valkey"),
 					pulumi.String("valkey"),
-					pulumi.String("'*.valkey-headless.valkey.svc.cluster.local'"),
+					pulumi.String("*.valkey-headless.valkey.svc.cluster.local"),
 					pulumi.String("valkey-headless.valkey.svc.cluster.local"),
 					pulumi.String("valkey-headless.valkey.svc"),
 					pulumi.String("valkey-headless.valkey"),

--- a/pkg/v1/valkey/valkey_helm_chart.go
+++ b/pkg/v1/valkey/valkey_helm_chart.go
@@ -8,11 +8,10 @@ import (
 )
 
 const (
-	clusterAppLabel   = "valkey"
-	clusterAppVersion = "8.1.2"
-	chartName         = "valkey"
-	chartRepo         = "oci://registry-1.docker.io/bitnamicharts/valkey"
-	chartVersion      = "3.0.16"
+	clusterAppLabel = "valkey"
+	chartName       = "valkey"
+	chartRepo       = "oci://registry-1.docker.io/bitnamicharts/valkey"
+	chartVersion    = "3.0.16"
 )
 
 // DeployValkeyCluster sets up the required resources needed to run Valkey including a namespace, TLS certificate, and
@@ -111,8 +110,14 @@ func newValkeyClusterHelmChartArgs(
 				"password": pulumi.String("password"),
 			},
 			"commonConfiguration": pulumi.String(aclContent),
+			"image": pulumi.Map{
+				"digest": pulumi.String("sha256:0384ca2eec63789450b2e07a00f377c2c9d0b548c2e346e1003bc0dd629fa71a"),
+			},
 			"sentinel": pulumi.Map{
 				"enabled": pulumi.Bool(true),
+				"image": pulumi.Map{
+					"digest": pulumi.String("sha256:071cb353bc17f27492655c710386d5e3afc5c36d8057ea5d48c5886da6f1bc3a"),
+				},
 				"resources": pulumi.Map{
 					"limits": pulumi.Map{
 						"cpu":    pulumi.String("600m"),

--- a/pkg/v1/valkey/valkey_helm_chart.go
+++ b/pkg/v1/valkey/valkey_helm_chart.go
@@ -92,11 +92,13 @@ func newValkeyClusterHelmChartArgs(
 			},
 			"sentinel": pulumi.Map{
 				"enabled": pulumi.Bool(true),
-				//"annotations": pulumi.Map{
-				//	"config.kubernetes.io/depends-on": pulumi.String(
-				//		fmt.Sprintf("/namespaces/%s/Secret/%s", clusterNamespace, clusterCertificateSecretName),
-				//	),
-				//},
+			},
+			"tls": pulumi.Map{
+				"enabled":         pulumi.Bool(true),
+				"existingSecret":  pulumi.String(clusterCertificateSecretName),
+				"certFilename":    pulumi.String("tls.crt"),
+				"certKeyFilename": pulumi.String("tls.key"),
+				"certCAFilename":  pulumi.String("ca.crt"),
 			},
 		},
 	}

--- a/pkg/v1/valkey/valkey_helm_chart.go
+++ b/pkg/v1/valkey/valkey_helm_chart.go
@@ -1,0 +1,104 @@
+package valkey
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	helmv4 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v4"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	clusterAppLabel   = "valkey"
+	clusterAppVersion = "8.1.2"
+	chartName         = "valkey"
+	chartRepo         = "oci://registry-1.docker.io/bitnamicharts/valkey"
+	chartVersion      = "3.0.16"
+)
+
+// DeployValkeyCluster sets up the required resources needed to run Valkey including a namespace, TLS certificate, and
+// Helm chart.
+func DeployValkeyCluster(
+	ctx *pulumi.Context,
+	provider *kubernetes.Provider,
+	deps []pulumi.Resource,
+) ([]pulumi.Resource, error) {
+	namespace, err := deployValkeyClusterNamespace(
+		ctx,
+		provider,
+		[]pulumi.Resource{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := deployValkeyClusterCertificate(
+		ctx,
+		namespace,
+		provider,
+		append(deps, namespace),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	chart, err := deployValkeyClusterHelmChart(
+		ctx,
+		namespace,
+		provider,
+		append(deps, namespace, cert),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return []pulumi.Resource{namespace, cert, chart}, nil
+}
+
+// deployValkeyClusterHelmChart deploys a Valkey cluster using the bitnami Helm chart.
+func deployValkeyClusterHelmChart(
+	ctx *pulumi.Context,
+	namespace *corev1.Namespace,
+	provider *kubernetes.Provider,
+	deps []pulumi.Resource,
+) (pulumi.Resource, error) {
+	args := newValkeyClusterHelmChartArgs(namespace)
+
+	chart, err := helmv4.NewChart(
+		ctx,
+		chartName,
+		args,
+		pulumi.Provider(provider),
+		pulumi.DependsOn(deps),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return chart, nil
+}
+
+// newValkeyClusterHelmChartArgs constructs the Helm chart values needed to deploy Valkey to k8s.
+func newValkeyClusterHelmChartArgs(
+	namespace *corev1.Namespace,
+) *helmv4.ChartArgs {
+	chartArgs := &helmv4.ChartArgs{
+		Chart:     pulumi.String(chartRepo),
+		Namespace: namespace.Metadata.Name(),
+		Version:   pulumi.String(chartVersion),
+		Values: pulumi.Map{
+			"architecture": pulumi.String("replication"),
+			"auth": pulumi.Map{
+				"enabled":  pulumi.Bool(true),
+				"password": pulumi.String("password"),
+			},
+			"sentinel": pulumi.Map{
+				"enabled": pulumi.Bool(true),
+				//"annotations": pulumi.Map{
+				//	"config.kubernetes.io/depends-on": pulumi.String(
+				//		fmt.Sprintf("/namespaces/%s/Secret/%s", clusterNamespace, clusterCertificateSecretName),
+				//	),
+				//},
+			},
+		},
+	}
+	return chartArgs
+}

--- a/pkg/v1/valkey/valkey_helm_chart.go
+++ b/pkg/v1/valkey/valkey_helm_chart.go
@@ -92,6 +92,16 @@ func newValkeyClusterHelmChartArgs(
 			},
 			"sentinel": pulumi.Map{
 				"enabled": pulumi.Bool(true),
+				"resources": pulumi.Map{
+					"limits": pulumi.Map{
+						"cpu":    pulumi.String("600m"),
+						"memory": pulumi.String("750Mi"),
+					},
+					"requests": pulumi.Map{
+						"cpu":    pulumi.String("500m"),
+						"memory": pulumi.String("500Mi"),
+					},
+				},
 			},
 			"tls": pulumi.Map{
 				"enabled":         pulumi.Bool(true),

--- a/pkg/v1/valkey/valkey_namespace.go
+++ b/pkg/v1/valkey/valkey_namespace.go
@@ -1,0 +1,44 @@
+package valkey
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+const (
+	clusterNamespace = "valkey"
+)
+
+// deployValkeyClusterNamespace creates the `valkey` namespace.
+func deployValkeyClusterNamespace(
+	ctx *pulumi.Context,
+	provider *kubernetes.Provider,
+	deps []pulumi.Resource,
+) (*corev1.Namespace, error) {
+	args := newValkeyClusterNamespaceArgs()
+	ns, err := corev1.NewNamespace(
+		ctx,
+		clusterNamespace,
+		args,
+		pulumi.Provider(provider),
+		pulumi.DependsOn(deps),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ns, nil
+}
+
+// newValkeyClusterNamespaceArgs returns the corev1.NamespaceArgs used to create the `valkey` namespace.
+func newValkeyClusterNamespaceArgs() *corev1.NamespaceArgs {
+	return &corev1.NamespaceArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name: pulumi.String(clusterNamespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String(clusterAppLabel),
+			},
+		},
+	}
+}

--- a/pkg/v1/valkey/valkey_user_acl.go
+++ b/pkg/v1/valkey/valkey_user_acl.go
@@ -3,10 +3,6 @@ package valkey
 import (
 	"bytes"
 	"fmt"
-	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
-	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
-	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"text/template"
 )
 
@@ -14,11 +10,7 @@ import (
 // or a result containing `<nil>`.
 var ErrTemplateParsingError = fmt.Errorf("error parsing ACL file template")
 
-const (
-	aclSecretName = "valkey-acl"
-)
-
-const aclTemplate = `
+const configTemplate = `
 {{ range $index, $user := .Users }}
 user {{ $user.Username }} on >{{ $user.Password }} -@ALL {{ range $cmd := $user.EnabledCommands }}{{ $cmd }} {{ end }}
 {{ end }}
@@ -36,53 +28,11 @@ type valkeyUser struct {
 	EnabledCommands []string
 }
 
-// deployValkeyUserACLSecret composes a string containing the contents of an ACL file. That string is then deployed as
-// a secret for Valkey to use.
-func deployValkeyUserACLSecret(
-	ctx *pulumi.Context,
-	namespace *corev1.Namespace,
-	provider *kubernetes.Provider,
-	deps []pulumi.Resource,
-) (*corev1.Secret, string, error) {
-	aclContent, err := newValkeyUserACL(
-		// TODO(2025-06-30): Add support to the template for creating users with no password
-		&valkeyUser{
-			Username:        "test",
-			Password:        "test",
-			EnabledCommands: []string{"+AUTH", "+PING", "+GET", "+SET", "~*"},
-		},
-		&valkeyUser{
-			Username:        "default",
-			Password:        "password",
-			EnabledCommands: []string{"+@ALL", "~*"},
-		},
-	)
-	if err != nil {
-		return nil, "", err
-	}
-
-	aclSecretArgs := newValkeyUserACLSecretArgs(
-		namespace,
-		aclContent,
-	)
-	aclSecret, err := corev1.NewSecret(
-		ctx,
-		aclSecretName,
-		aclSecretArgs,
-		pulumi.Provider(provider),
-		pulumi.DependsOn(deps),
-	)
-	if err != nil {
-		return nil, "", err
-	}
-	return aclSecret, aclContent, nil
-}
-
 // newValkeyUserACL uses text templating to compose the contents of an ACL file as a string.
 func newValkeyUserACL(
 	users ...*valkeyUser,
 ) (string, error) {
-	tmp, err := template.New("valkey.acl").Parse(aclTemplate)
+	tmp, err := template.New("valkey.acl").Parse(configTemplate)
 	if err != nil {
 		return "", err
 	}
@@ -104,26 +54,4 @@ func newValkeyUserACL(
 	}
 
 	return contents, nil
-}
-
-// newValkeyUserACLSecretArgs creates the Secret specs that contain the Valkey ACL file contents.
-func newValkeyUserACLSecretArgs(
-	namespace *corev1.Namespace,
-	aclContent string,
-) *corev1.SecretArgs {
-	return &corev1.SecretArgs{
-		ApiVersion: pulumi.String("v1"),
-		Kind:       pulumi.String("Secret"),
-		Type:       pulumi.String("Opaque"),
-		Metadata: metav1.ObjectMetaArgs{
-			Name:      pulumi.String(aclSecretName),
-			Namespace: namespace.Metadata.Name(),
-			Labels: pulumi.StringMap{
-				"app": pulumi.String(clusterAppLabel),
-			},
-		},
-		StringData: pulumi.StringMap{
-			aclSecretName: pulumi.String(aclContent),
-		},
-	}
 }

--- a/pkg/v1/valkey/valkey_user_acl.go
+++ b/pkg/v1/valkey/valkey_user_acl.go
@@ -1,0 +1,129 @@
+package valkey
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"text/template"
+)
+
+// ErrTemplateParsingError indicates that there was an issue parsing the acls template that resulted in an empty result
+// or a result containing `<nil>`.
+var ErrTemplateParsingError = fmt.Errorf("error parsing ACL file template")
+
+const (
+	aclSecretName = "valkey-acl"
+)
+
+const aclTemplate = `
+{{ range $index, $user := .Users }}
+user {{ $user.Username }} on >{{ $user.Password }} -@ALL {{ range $cmd := $user.EnabledCommands }}{{ $cmd }} {{ end }}
+{{ end }}
+
+# Enable AOF https://valkey.io/docs/topics/persistence.html
+appendonly yes
+# Disable RDB persistence, AOF persistence already enabled.
+save ""
+`
+
+// valkeyUser describes a user in the Valkey ACL file and their allowed commands. All users start with -@ALL by default.
+type valkeyUser struct {
+	Username        string
+	Password        string
+	EnabledCommands []string
+}
+
+// deployValkeyUserACLSecret composes a string containing the contents of an ACL file. That string is then deployed as
+// a secret for Valkey to use.
+func deployValkeyUserACLSecret(
+	ctx *pulumi.Context,
+	namespace *corev1.Namespace,
+	provider *kubernetes.Provider,
+	deps []pulumi.Resource,
+) (*corev1.Secret, string, error) {
+	aclContent, err := newValkeyUserACL(
+		// TODO(2025-06-30): Add support to the template for creating users with no password
+		&valkeyUser{
+			Username:        "test",
+			Password:        "test",
+			EnabledCommands: []string{"+AUTH", "+PING", "+GET", "+SET", "~*"},
+		},
+		&valkeyUser{
+			Username:        "default",
+			Password:        "password",
+			EnabledCommands: []string{"+@ALL", "~*"},
+		},
+	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	aclSecretArgs := newValkeyUserACLSecretArgs(
+		namespace,
+		aclContent,
+	)
+	aclSecret, err := corev1.NewSecret(
+		ctx,
+		aclSecretName,
+		aclSecretArgs,
+		pulumi.Provider(provider),
+		pulumi.DependsOn(deps),
+	)
+	if err != nil {
+		return nil, "", err
+	}
+	return aclSecret, aclContent, nil
+}
+
+// newValkeyUserACL uses text templating to compose the contents of an ACL file as a string.
+func newValkeyUserACL(
+	users ...*valkeyUser,
+) (string, error) {
+	tmp, err := template.New("valkey.acl").Parse(aclTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	templateData := struct {
+		Users []*valkeyUser
+	}{
+		Users: users,
+	}
+	templateDestination := bytes.NewBuffer(nil)
+	err = tmp.Execute(templateDestination, &templateData)
+	if err != nil {
+		return "", err
+	}
+
+	contents := templateDestination.String()
+	if contents == "" || contents == "<nil>" {
+		return "", ErrTemplateParsingError
+	}
+
+	return contents, nil
+}
+
+// newValkeyUserACLSecretArgs creates the Secret specs that contain the Valkey ACL file contents.
+func newValkeyUserACLSecretArgs(
+	namespace *corev1.Namespace,
+	aclContent string,
+) *corev1.SecretArgs {
+	return &corev1.SecretArgs{
+		ApiVersion: pulumi.String("v1"),
+		Kind:       pulumi.String("Secret"),
+		Type:       pulumi.String("Opaque"),
+		Metadata: metav1.ObjectMetaArgs{
+			Name:      pulumi.String(aclSecretName),
+			Namespace: namespace.Metadata.Name(),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String(clusterAppLabel),
+			},
+		},
+		StringData: pulumi.StringMap{
+			aclSecretName: pulumi.String(aclContent),
+		},
+	}
+}

--- a/scripts/kind_create_cluster.sh
+++ b/scripts/kind_create_cluster.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+MACHINE_NAME="podman-machine-default"
+MACHINE_STATUS="Currently running"
+
+# Verify there's a Podman machine running
+if ! podman machine list 2>/dev/null | grep -q "${MACHINE_NAME}.*${MACHINE_STATUS}"; then
+    echo "Error: Podman machine '${MACHINE_NAME}' is not running."
+    echo "Please start the Podman machine with: podman machine start ${MACHINE_NAME}"
+    exit 1
+fi
+
+CLUSTER_NAME="kind"
+
+# Check if a cluster with the name "kind" already exists
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+    echo "A Kind cluster named '${CLUSTER_NAME}' is already running. Skipping creation."
+    exit 0
+fi
+
+# Create the cluster if it doesn't exist
+echo "Creating Kind cluster '${CLUSTER_NAME}'..."
+kind create cluster --config kind-config.yaml

--- a/scripts/kind_delete_cluster.sh
+++ b/scripts/kind_delete_cluster.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+MACHINE_NAME="podman-machine-default"
+MACHINE_STATUS="Currently running"
+
+# Verify there's a Podman machine running
+if ! podman machine list 2>/dev/null | grep -q "${MACHINE_NAME}.*${MACHINE_STATUS}"; then
+    echo "Error: Podman machine '${MACHINE_NAME}' is not running."
+    echo "Please start the Podman machine with: podman machine start ${MACHINE_NAME}"
+    exit 1
+fi
+
+kind delete cluster
+
+podman container kill --all
+podman container rm --all
+podman image rm --all
+podman volume rm --all


### PR DESCRIPTION
## Summary

This change replaces deploying standalone Dragonfly with Valkey running in sentinel mode.

This is motivated by bugs in the Dragonfly operator like no TLS on the admin port being a hardcoded server arg that cannot be overridden.
